### PR TITLE
Remove categories from deck before deleting it

### DIFF
--- a/backend/src/main/java/at/ac/tuwien/sepm/groupphase/backend/entity/Deck.java
+++ b/backend/src/main/java/at/ac/tuwien/sepm/groupphase/backend/entity/Deck.java
@@ -89,13 +89,13 @@ public class Deck {
         this.updatedAt = updatedAt;
     }
 
-    //public Set<Comment> getComments() {
-    //    return comments;
-    //}
+    public Set<Comment> getComments() {
+       return comments;
+    }
 
-    //public void setComments(Set<Comment> comments) {
-    //    this.comments = comments;
-    //}
+    public void setComments(Set<Comment> comments) {
+       this.comments = comments;
+    }
 
 
     public Set<Card> getCards() {

--- a/backend/src/main/java/at/ac/tuwien/sepm/groupphase/backend/profiles/datagenerator/Agent.java
+++ b/backend/src/main/java/at/ac/tuwien/sepm/groupphase/backend/profiles/datagenerator/Agent.java
@@ -109,6 +109,7 @@ public class Agent {
         comment.setCreatedBy(user);
         deck.setCreatedAt(LocalDateTime.of(2020, 1, 1, 1, 1));
         deck.setUpdatedAt(LocalDateTime.of(2020, 2, 1, 1, 1));
+        deck.getComments().add(comment);
         user.getComments().add(comment);
         beforeReturn(comment);
         return comment;

--- a/backend/src/main/java/at/ac/tuwien/sepm/groupphase/backend/service/impl/SimpleDeckService.java
+++ b/backend/src/main/java/at/ac/tuwien/sepm/groupphase/backend/service/impl/SimpleDeckService.java
@@ -154,11 +154,10 @@ public class SimpleDeckService implements DeckService {
     @Override
     public void delete(Long id) {
         LOGGER.debug("Delete deck with id {}", id);
-        try {
-            deckRepository.deleteById(id);
-        } catch (EmptyResultDataAccessException e) {
-            throw new DeckNotFoundException(String.format("Could not find card deck with id %d", id));
-        }
+        Deck deck = findOneOrThrow(id);
+        for (Category category : deck.getCategories())
+            category.getDecks().remove(deck);
+        deckRepository.deleteById(id);
 	}
 
     @Transactional


### PR DESCRIPTION
Fixes #13 

JPA automatically removes relationships for the owner entity (Category) but not for the other side (Deck). So we have to make it manually when deleting a Deck.