### PR TITLE
Display number of due cards in dashboard

### DIFF
--- a/backend/src/main/java/at/ac/tuwien/sepm/groupphase/backend/endpoint/dto/DeckProgressDto.java
+++ b/backend/src/main/java/at/ac/tuwien/sepm/groupphase/backend/endpoint/dto/DeckProgressDto.java
@@ -5,7 +5,15 @@ import lombok.Data;
 
 @Data
 public class DeckProgressDto {
+    // total number of cards to learn
+    private int totalCount;
+
+    // cards without progress
     private int newCount;
+
+    // cards in learning mode
     private int learningCount;
-    private int toReviewCount;
+
+    // total number of cards which are due
+    private int dueCount;
 }

--- a/backend/src/main/java/at/ac/tuwien/sepm/groupphase/backend/profiles/datagenerator/Agent.java
+++ b/backend/src/main/java/at/ac/tuwien/sepm/groupphase/backend/profiles/datagenerator/Agent.java
@@ -174,7 +174,7 @@ public class Agent {
         return deck;
     }
 
-    public Progress createProgress(Card card, Progress.Status status, boolean reverse) {
+    public Progress createProgressNotDue(Card card, Progress.Status status, boolean reverse) {
         Progress progress = new Progress();
         progress.setDue(LocalDateTime.now().plusDays(3L));
         progress.setEasinessFactor(5);

--- a/backend/src/main/java/at/ac/tuwien/sepm/groupphase/backend/repository/CardRepository.java
+++ b/backend/src/main/java/at/ac/tuwien/sepm/groupphase/backend/repository/CardRepository.java
@@ -87,7 +87,15 @@ public interface CardRepository extends JpaRepository<Card, Long> {
     @Query(nativeQuery = true,
         value = "SELECT *" + findNextCardsQuery + findNextCardsOrder,
         countQuery = "SELECT count(*)" + findNextCardsQuery)
-    List<Card> findNextCards(@Param("deckId") Long deckId, @Param("userId") Long userId, @Param("reverse") boolean reverse, Pageable pageable);
+    Page<Card> findNextCards(@Param("deckId") Long deckId, @Param("userId") Long userId, @Param("reverse") boolean reverse, Pageable pageable);
+
+    /**
+     * Number of currently due cards.
+     * Same as totalElements of {@link #findNextCards(Long, Long, boolean, Pageable)}
+     */
+    @Query(nativeQuery = true,
+        value = "SELECT count(*)" + findNextCardsQuery)
+    long dueCardsCount(@Param("deckId") Long deckId, @Param("userId") Long userId, @Param("reverse") boolean reverse);
 
     /**
      * Filter front texts by existing front texts in deck

--- a/backend/src/main/java/at/ac/tuwien/sepm/groupphase/backend/service/impl/SimpleDeckService.java
+++ b/backend/src/main/java/at/ac/tuwien/sepm/groupphase/backend/service/impl/SimpleDeckService.java
@@ -192,13 +192,18 @@ public class SimpleDeckService implements DeckService {
      */
     @Transactional
     public DeckProgressDto getDeckProgress(Deck deck, User user, boolean reverse) {
+        int totalCount = deckRepository.countCards(deck);
+        int dueCount = (int) cardRepository.dueCardsCount(deck.getId(), user.getId(), reverse);
+        int learningCount = deckRepository.countProgressStatuses(user, deck, reverse, Progress.Status.LEARNING);
+        int reviewCount = deckRepository.countProgressStatuses(user, deck, reverse, Progress.Status.REVIEWING);
+        int newCount = totalCount - (learningCount + reviewCount);
+
         DeckProgressDto dto = new DeckProgressDto();
-        dto.setLearningCount(deckRepository.countProgressStatuses(user, deck, reverse, Progress.Status.LEARNING));
-        dto.setToReviewCount(deckRepository.countProgressStatuses(user, deck, reverse, Progress.Status.REVIEWING));
-        if (dto.getLearningCount() == 0 && dto.getToReviewCount() == 0)
-            return null;
-        dto.setNewCount(deckRepository.countCards(deck) - dto.getLearningCount() - dto.getToReviewCount());
-        return dto;
+        dto.setTotalCount(totalCount);
+        dto.setNewCount(newCount);
+        dto.setLearningCount(learningCount);
+        dto.setDueCount(dueCount);
+        return (newCount == totalCount) ? null : dto;
     }
 
     @Override

--- a/backend/src/main/java/at/ac/tuwien/sepm/groupphase/backend/service/impl/SimpleLearnService.java
+++ b/backend/src/main/java/at/ac/tuwien/sepm/groupphase/backend/service/impl/SimpleLearnService.java
@@ -50,7 +50,7 @@ public class SimpleLearnService implements LearnService {
             throw new BadRequestException("deckId does not exist");
         }
 
-        return cardRepository.findNextCards(deckId, user.getId(), reverse, pageable);
+        return cardRepository.findNextCards(deckId, user.getId(), reverse, pageable).getContent();
     }
 
     private static final int[] LEARNING_STEPS = {1, 10}; // in minutes

--- a/backend/src/test/java/at/ac/tuwien/sepm/groupphase/backend/integrationtest/DeckEndpointTest.java
+++ b/backend/src/test/java/at/ac/tuwien/sepm/groupphase/backend/integrationtest/DeckEndpointTest.java
@@ -574,10 +574,10 @@ public class DeckEndpointTest extends TestDataGenerator {
         Card card2 = agent.createCardIn(deck);
         Card card3 = agent.createCardIn(deck);
         Card card4 = agent.createCardIn(deck);
-        agent.createProgress(card2, Progress.Status.LEARNING, false);
-        agent.createProgress(card3, Progress.Status.REVIEWING, false);
-        agent.createProgress(card4, Progress.Status.REVIEWING, false);
-        agent.createProgress(card4, Progress.Status.REVIEWING, true);
+        agent.createProgressNotDue(card2, Progress.Status.LEARNING, false);
+        agent.createProgressNotDue(card3, Progress.Status.REVIEWING, false);
+        agent.createProgressNotDue(card4, Progress.Status.REVIEWING, false);
+        agent.createProgressNotDue(card4, Progress.Status.REVIEWING, true);
 
         mvc.perform(get("/api/v1/decks/progress")
             .with(login(user.getAuthId())))
@@ -585,12 +585,14 @@ public class DeckEndpointTest extends TestDataGenerator {
             .andExpect(jsonPath("$.content", hasSize(1)))
             .andExpect(jsonPath("$.content[0].deckId").value(deck.getId()))
             .andExpect(jsonPath("$.content[0].deckName").value(deck.getName()))
+            .andExpect(jsonPath("$.content[0].normal.totalCount").value(4))
             .andExpect(jsonPath("$.content[0].normal.newCount").value(1))
             .andExpect(jsonPath("$.content[0].normal.learningCount").value(1))
-            .andExpect(jsonPath("$.content[0].normal.toReviewCount").value(2))
+            .andExpect(jsonPath("$.content[0].normal.dueCount").value(1))
+            .andExpect(jsonPath("$.content[0].reverse.totalCount").value(4))
             .andExpect(jsonPath("$.content[0].reverse.newCount").value(3))
             .andExpect(jsonPath("$.content[0].reverse.learningCount").value(0))
-            .andExpect(jsonPath("$.content[0].reverse.toReviewCount").value(1));
+            .andExpect(jsonPath("$.content[0].reverse.dueCount").value(3));
     }
 
     @Test
@@ -599,7 +601,7 @@ public class DeckEndpointTest extends TestDataGenerator {
         User user = agent.getUser();
         Deck deck = agent.createDeck();
         Card card = agent.createCardIn(deck);
-        agent.createProgress(card, Progress.Status.LEARNING, false);
+        agent.createProgressNotDue(card, Progress.Status.LEARNING, false);
 
         mvc.perform(get("/api/v1/decks/progress")
             .with(login(user.getAuthId())))
@@ -657,7 +659,7 @@ public class DeckEndpointTest extends TestDataGenerator {
         User user = agent.getUser();
         Deck deck = agent.createDeck();
         Card card = agent.createCardIn(deck);
-        agent.createProgress(card, Progress.Status.LEARNING, true);
+        agent.createProgressNotDue(card, Progress.Status.LEARNING, true);
 
         mvc.perform(delete("/api/v1/decks/{deckId}/progress", deck.getId())
             .queryParam("reverse", "true")

--- a/backend/src/test/java/at/ac/tuwien/sepm/groupphase/backend/integrationtest/UserEndpointTest.java
+++ b/backend/src/test/java/at/ac/tuwien/sepm/groupphase/backend/integrationtest/UserEndpointTest.java
@@ -456,7 +456,7 @@ public class UserEndpointTest extends TestDataGenerator {
         revisionCreate.setMessage("created this card");
         Card card = agent.createCardIn(deck, revisionCreate);
 
-        Progress progress = agent.createProgress(card, Progress.Status.LEARNING, false);
+        Progress progress = agent.createProgressNotDue(card, Progress.Status.LEARNING, false);
 
         mvc.perform(get("/api/v1/users/{userId}/export", user.getId())
             .with(login(user.getAuthId())))

--- a/backend/src/test/java/at/ac/tuwien/sepm/groupphase/backend/unittests/DeckRepositoryTest.java
+++ b/backend/src/test/java/at/ac/tuwien/sepm/groupphase/backend/unittests/DeckRepositoryTest.java
@@ -144,10 +144,10 @@ public class DeckRepositoryTest extends TestDataGenerator {
         Card card2 = agent.createCardIn(deck);
         Card card3 = agent.createCardIn(deck);
         Card card4 = agent.createCardIn(deck);
-        agent.createProgress(card2, Progress.Status.LEARNING, false);
-        agent.createProgress(card3, Progress.Status.REVIEWING, false);
-        agent.createProgress(card4, Progress.Status.REVIEWING, false);
-        agent.createProgress(card4, Progress.Status.REVIEWING, true);
+        agent.createProgressNotDue(card2, Progress.Status.LEARNING, false);
+        agent.createProgressNotDue(card3, Progress.Status.REVIEWING, false);
+        agent.createProgressNotDue(card4, Progress.Status.REVIEWING, false);
+        agent.createProgressNotDue(card4, Progress.Status.REVIEWING, true);
 
         assertAll(
             () -> assertEquals(1, deckRepository.countProgressStatuses(user, deck, false, Progress.Status.LEARNING)),

--- a/backend/src/test/java/at/ac/tuwien/sepm/groupphase/backend/unittests/ProgressRepositoryTest.java
+++ b/backend/src/test/java/at/ac/tuwien/sepm/groupphase/backend/unittests/ProgressRepositoryTest.java
@@ -44,7 +44,7 @@ public class ProgressRepositoryTest extends TestDataGenerator {
                 user.getId(),
                 false,
                 Pageable.unpaged()
-            ).size()
+            ).getTotalElements()
         );
     }
 
@@ -63,7 +63,7 @@ public class ProgressRepositoryTest extends TestDataGenerator {
                 user.getId(),
                 false,
                 Pageable.unpaged()
-            ).size()
+            ).getTotalElements()
         );
     }
 
@@ -82,7 +82,7 @@ public class ProgressRepositoryTest extends TestDataGenerator {
                 user.getId(),
                 false,
                 Pageable.unpaged()
-            ).size()
+            ).getTotalElements()
         );
     }
 
@@ -101,7 +101,7 @@ public class ProgressRepositoryTest extends TestDataGenerator {
                 user.getId(),
                 true,
                 Pageable.unpaged()
-            ).size()
+            ).getTotalElements()
         );
     }
 
@@ -120,7 +120,7 @@ public class ProgressRepositoryTest extends TestDataGenerator {
                 user.getId(),
                 false,
                 Pageable.unpaged()
-            ).size()
+            ).getTotalElements()
         );
     }
 
@@ -139,7 +139,7 @@ public class ProgressRepositoryTest extends TestDataGenerator {
                 user.getId(),
                 false,
                 Pageable.unpaged()
-            ).size()
+            ).getTotalElements()
         );
     }
 }

--- a/frontend/cypress/integration/e2e/core.spec.ts
+++ b/frontend/cypress/integration/e2e/core.spec.ts
@@ -92,7 +92,8 @@ describe('E2E Core functionalities', () => {
       .parent()
       .find('ul')
       .should('include.text', deckName)
-      .and('include.text', '1 learning');
+      .and('include.text', '1 learning')
+      .and('include.text', '0 of 1 cards are due');
 
     // Search for Decks
     cy.get('input[placeholder*="Find decks"]').type(`${deckName}{enter}`);

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -48,12 +48,14 @@
         {{ progress.deckName }}
         <i *ngIf="progress.reverse" class="fas fa-undo ml-2"></i>
         <div class="float-right">
-          <span class="text-primary">{{ progress.newCount }} new</span>
-          &nbsp;
-          <span class="text-danger">{{ progress.learningCount }} learning</span>
-          &nbsp;
-          <span class="text-success">
-            {{ progress.toReviewCount }} to review
+          <span *ngIf="progress.newCount" class="text-primary px-1">
+            {{ progress.newCount }} new
+          </span>
+          <span *ngIf="progress.learningCount" class="text-danger px-1">
+            {{ progress.learningCount }} learning
+          </span>
+          <span class="px-1">
+            {{ progress.dueCount }} of {{ progress.totalCount }} cards are due
           </span>
           <button
             class="btn btn-outline-danger ml-2"

--- a/frontend/src/app/dtos/deckProgress.ts
+++ b/frontend/src/app/dtos/deckProgress.ts
@@ -1,7 +1,8 @@
 export class DeckProgress {
   constructor(
+    public totalCount: number,
     public newCount: number,
     public learningCount: number,
-    public toReviewCount: number
+    public dueCount: number
   ) {}
 }


### PR DESCRIPTION
Replaces "to review" count with a "{due} of {total} cards are due" in the dashboard.

Example Screenshot:
![Screenshot of progress counts in dashboard](https://user-images.githubusercontent.com/21040751/89109923-d5061900-d445-11ea-86fd-bf6fcf9336c1.png)

Closes #14 