### PR TITLE
Insert back side html only when card is flipped

### DIFF
--- a/frontend/src/app/components/learn-deck/learn-deck.component.css
+++ b/frontend/src/app/components/learn-deck/learn-deck.component.css
@@ -44,9 +44,6 @@
   transition: transform 1s;
   transform: rotateX(180deg);
 }
-.flipped .please-flip {
-  display: none;
-}
 
 .img-front {
   max-height: 180px;

--- a/frontend/src/app/components/learn-deck/learn-deck.component.html
+++ b/frontend/src/app/components/learn-deck/learn-deck.component.html
@@ -19,10 +19,10 @@
       ></div>
       <div class="scene text-center" (click)="onFlip()">
         <div class="flip-card" [ngClass]="flipped ? 'flipped' : ''">
-          <div class="flip-card-face please-flip">
+          <div *ngIf="!flipped" class="flip-card-face">
             flip backside by clicking here or pressing spacebar
           </div>
-          <div class="flip-card-face flip-card-face-back">
+          <div *ngIf="flipped" class="flip-card-face flip-card-face-back">
             <img
               class="img-fluid img-thumbnail img-back my-3"
               *ngIf="card.imageBackUrl"


### PR DESCRIPTION
Prevents an unnecessary scrollbar from appearing on smaller screens, because the back side had a height but was invisible.